### PR TITLE
Move poison spells

### DIFF
--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/EmpireWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/EmpireWandInteraction.java
@@ -73,12 +73,6 @@ public class EmpireWandInteraction {
 							loreItems.set(0, "Cloud");
 							break;
 						case "Cloud":
-							loreItems.set(0, "Poison Wave");
-							break;
-						case "Poison Wave":
-							loreItems.set(0, "Poison Spark");
-							break;
-						case "Poison Spark":
 							loreItems.set(0, "Empire Spark");
 							break;
 
@@ -127,12 +121,6 @@ public class EmpireWandInteraction {
 						break;
 					case "Cloud":
 						CloudSpell.Execute(loc, p);
-						break;
-					case "Poison Wave":
-						PoisonWaveSpell.Execute(loc, p);
-						break;
-					case "Poison Spark":
-						PoisonSparkSpell.Execute(loc, p);
 						break;
 					case "Empire Spark":
 						EmpireSparkSpell.Execute(loc, p);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/ScytheWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/ScytheWandInteraction.java
@@ -1,6 +1,8 @@
 package moe.myuuiii.empirewandplus.listeners.wandinteraction;
 
 import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.spells.PoisonSparkSpell;
+import moe.myuuiii.empirewandplus.spells.PoisonWaveSpell;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -55,14 +57,14 @@ public class ScytheWandInteraction {
 					loreItems = wand.getItemMeta().getLore();
 
 					switch (wand.getItemMeta().getLore().get(0)) {
-						case "":
-							loreItems.set(0, "");
+						case "Poison Wave":
+							loreItems.set(0, "Poison Spark");
 							break;
 
 						// reset
-						// case "":
+						case "Poison Spark":
 						default:
-							loreItems.set(0, "");
+							loreItems.set(0, "Poison Wave");
 							break;
 					}
 				} else {
@@ -90,7 +92,12 @@ public class ScytheWandInteraction {
 				// Spell execution
 				//
 				switch (wand.getItemMeta().getLore().get(0)) {
-
+					case "Poison Wave":
+						PoisonWaveSpell.Execute(loc, p);
+						break;
+					case "Poison Spark":
+						PoisonSparkSpell.Execute(loc, p);
+						break;
 				}
 			}
 		}


### PR DESCRIPTION
# In this pull request

## Spells
- Moved the Poison Spark spell from the Empire Wand to the Poison Scythe Wand
- Moved the Poison Wave spell from the Empire Wand to the Poison Scythe Wand