### PR TITLE
Create Cloud Spells

### DIFF
--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/App.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/App.java
@@ -38,7 +38,10 @@ public class App extends JavaPlugin {
 
     public void registerRunnables() {
 
-        // Cloud
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new CloudRunnable(), 10L, 0L);
+        // Cloud runnables
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new BloodCloudRunnable(), 10L, 0L);
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new CelestialCloudRunnable(), 10L, 0L);
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new EmpireCloudRunnable(), 10L, 0L);
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, new PoisonCloudRunnable(), 10L, 0L);
     }
 }

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Data.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Data.java
@@ -30,11 +30,14 @@ public class Data {
 	public static ArrayList<Snowball> lightningBolts = new ArrayList<Snowball>();
 	public static ArrayList<Snowball> empireComets = new ArrayList<Snowball>();
 
+	public static ArrayList<UUID> bloodCloudUsers = new ArrayList<>();
+	public static ArrayList<UUID> celestialCloudUsers = new ArrayList<>();
+	public static ArrayList<UUID> empireCloudUsers = new ArrayList<>();
+	public static ArrayList<UUID> poisonCloudUsers = new ArrayList<>();
+
 	public static ArrayList<Snowball> poisonWaves = new ArrayList<Snowball>();
 	public static ArrayList<UUID> poisonUsers = new ArrayList<UUID>();
 
 	public static ArrayList<Snowball> bloodWaves = new ArrayList<Snowball>();
 	public static ArrayList<UUID> bloodUsers = new ArrayList<UUID>();
-
-	public static ArrayList<UUID> cloudUsers = new ArrayList<UUID>();
 }

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Spells.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Spells.java
@@ -3,16 +3,19 @@ package moe.myuuiii.empirewandplus;
 public class Spells {
 	public static final String BloodSpark = "Blood Spark";
 	public static final String BloodWave = "Blood Wave";
+	public static final String BloodCloud = "Blood Cloud";
 
 	public static final String Lightning = "Lightning";
+	public static final String CelestialCloud = "Celestial Cloud";
 
 	public static final String Launch = "Launch";
 	public static final String Fireball = "Fireball";
+
 	public static final String EmpireComet = "Empire Comet";
 	public static final String EmpireSpark = "Empire Spark";
+	public static final String EmpireCloud = "Empire Cloud";
 
 	public static final String PoisonWave = "Poison Wave";
 	public static final String PoisonSpark = "Poison Spark";
-
-	public static final String Cloud = "Cloud";
+	public static final String PoisonCloud = "Poison Cloud";
 }

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/WandSpellLists.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/WandSpellLists.java
@@ -5,18 +5,18 @@ import java.util.List;
 
 public class WandSpellLists {
 	public static final List<String> EmpireWandSpells = Arrays.asList(new String[] {
-			Spells.Launch, Spells.Fireball, Spells.EmpireComet, Spells.EmpireSpark
+			Spells.Launch, Spells.Fireball, Spells.EmpireComet, Spells.EmpireSpark, Spells.EmpireCloud
 	});
 
 	public static final List<String> BloodWandSpells = Arrays.asList(new String[] {
-			Spells.BloodSpark, Spells.BloodWave
+			Spells.BloodSpark, Spells.BloodWave, Spells.BloodCloud
 	});
 
 	public static final List<String> PoisonScytheWandSpells = Arrays.asList(new String[] {
-			Spells.PoisonSpark, Spells.PoisonWave
+			Spells.PoisonSpark, Spells.PoisonWave, Spells.PoisonCloud
 	});
 
 	public static final List<String> CelestialWandSpells = Arrays.asList(new String[] {
-			Spells.Lightning
+			Spells.Lightning, Spells.CelestialCloud
 	});
 }

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/handlers/CloudHandler.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/handlers/CloudHandler.java
@@ -1,0 +1,22 @@
+package moe.myuuiii.empirewandplus.handlers;
+
+import java.util.UUID;
+
+import moe.myuuiii.empirewandplus.Data;
+
+public class CloudHandler {
+	public static void DisableCloud(UUID uniqueId) {
+
+		if (Data.bloodCloudUsers.contains(uniqueId))
+			Data.bloodCloudUsers.remove(uniqueId);
+
+		if (Data.celestialCloudUsers.contains(uniqueId))
+			Data.celestialCloudUsers.remove(uniqueId);
+
+		if (Data.empireCloudUsers.contains(uniqueId))
+			Data.empireCloudUsers.remove(uniqueId);
+
+		if (Data.poisonCloudUsers.contains(uniqueId))
+			Data.poisonCloudUsers.remove(uniqueId);
+	}
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/handlers/SpellHandler.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/handlers/SpellHandler.java
@@ -24,12 +24,18 @@ public class SpellHandler {
 			case Spells.BloodWave:
 				BloodWaveSpell.Execute(loc, p);
 				break;
+			case Spells.BloodCloud:
+				BloodCloudSpell.Execute(loc, p);
+				break;
 
 			//
 			// Celestial wand
 			//
 			case Spells.Lightning:
 				LightningSpell.Execute(loc, p);
+				break;
+			case Spells.CelestialCloud:
+				CelestialCloudSpell.Execute(loc, p);
 				break;
 
 			//
@@ -47,6 +53,9 @@ public class SpellHandler {
 			case Spells.EmpireSpark:
 				EmpireSparkSpell.Execute(loc, p);
 				break;
+			case Spells.EmpireCloud:
+				EmpireCloudSpell.Execute(loc, p);
+				break;
 
 			//
 			// Poison scythe wand
@@ -57,12 +66,8 @@ public class SpellHandler {
 			case Spells.PoisonSpark:
 				PoisonSparkSpell.Execute(loc, p);
 				break;
-
-			//
-			// Spells to be removed
-			//
-			case Spells.Cloud:
-				CloudSpell.Execute(loc, p);
+			case Spells.PoisonCloud:
+				PoisonCloudSpell.Execute(loc, p);
 				break;
 		}
 	}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/BloodCloudRunnable.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/BloodCloudRunnable.java
@@ -1,0 +1,35 @@
+package moe.myuuiii.empirewandplus.runnables;
+
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Particle.DustOptions;
+import org.bukkit.entity.Player;
+
+import moe.myuuiii.empirewandplus.Data;
+
+public class BloodCloudRunnable implements Runnable {
+
+	//
+	// Settings
+	//
+	private static int _particleDensityModifier = 3;
+
+	@Override
+	public void run() {
+		for (UUID uuid : Data.bloodCloudUsers) {
+			if (Bukkit.getPlayer(uuid) != null) {
+				Player p = Bukkit.getPlayer(uuid);
+				Location l = p.getLocation();
+				l.add(0, 0.1, 0);
+				p.getWorld().spawnParticle(Particle.REDSTONE, l, 5 * _particleDensityModifier, 0.3, 0.0, 0.3, 0,
+						new DustOptions(Color.fromRGB(255, 0, 0), 2));
+				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3, 0);
+			}
+		}
+	}
+
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/CelestialCloudRunnable.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/CelestialCloudRunnable.java
@@ -1,0 +1,33 @@
+package moe.myuuiii.empirewandplus.runnables;
+
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+
+import moe.myuuiii.empirewandplus.Data;
+
+public class CelestialCloudRunnable implements Runnable {
+
+	//
+	// Settings
+	//
+	private static int _particleDensityModifier = 3;
+
+	@Override
+	public void run() {
+		for (UUID uuid : Data.celestialCloudUsers) {
+			if (Bukkit.getPlayer(uuid) != null) {
+				Player p = Bukkit.getPlayer(uuid);
+				Location l = p.getLocation();
+				l.add(0, 0.1, 0);
+				p.getWorld().spawnParticle(Particle.FIREWORKS_SPARK, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3,
+						0);
+				p.getWorld().spawnParticle(Particle.CLOUD, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3, 0);
+			}
+		}
+	}
+
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/EmpireCloudRunnable.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/EmpireCloudRunnable.java
@@ -3,13 +3,15 @@ package moe.myuuiii.empirewandplus.runnables;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
+import org.bukkit.Particle.DustOptions;
 import org.bukkit.entity.Player;
 
 import moe.myuuiii.empirewandplus.Data;
 
-public class CloudRunnable implements Runnable {
+public class EmpireCloudRunnable implements Runnable {
 
 	//
 	// Settings
@@ -18,13 +20,15 @@ public class CloudRunnable implements Runnable {
 
 	@Override
 	public void run() {
-		for (UUID uuid : Data.cloudUsers) {
+		for (UUID uuid : Data.empireCloudUsers) {
 			if (Bukkit.getPlayer(uuid) != null) {
 				Player p = Bukkit.getPlayer(uuid);
 				Location l = p.getLocation();
 				l.add(0, 0.1, 0);
-				p.getWorld().spawnParticle(Particle.CLOUD, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3, 0.01);
-				p.getWorld().spawnParticle(Particle.SNOWFLAKE, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3, 0);
+				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3,
+						0.01);
+				p.getWorld().spawnParticle(Particle.REDSTONE, l, 5 * _particleDensityModifier, 0.3, 0.0, 0.3, 0,
+						new DustOptions(Color.fromRGB(255, 0, 200), 2));
 			}
 		}
 	}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/PoisonCloudRunnable.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/runnables/PoisonCloudRunnable.java
@@ -1,0 +1,35 @@
+package moe.myuuiii.empirewandplus.runnables;
+
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.Particle.DustOptions;
+import org.bukkit.entity.Player;
+
+import moe.myuuiii.empirewandplus.Data;
+
+public class PoisonCloudRunnable implements Runnable {
+
+	//
+	// Settings
+	//
+	private static int _particleDensityModifier = 3;
+
+	@Override
+	public void run() {
+		for (UUID uuid : Data.poisonCloudUsers) {
+			if (Bukkit.getPlayer(uuid) != null) {
+				Player p = Bukkit.getPlayer(uuid);
+				Location l = p.getLocation();
+				l.add(0, 0.1, 0);
+				p.getWorld().spawnParticle(Particle.REDSTONE, l, 5 * _particleDensityModifier, 0.3, 0.0, 0.3, 0,
+						new DustOptions(Color.fromRGB(0, 255, 0), 2));
+				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, l, 10 * _particleDensityModifier, 0.3, 0.0, 0.3, 0);
+			}
+		}
+	}
+
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/BloodCloudSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/BloodCloudSpell.java
@@ -1,13 +1,15 @@
 package moe.myuuiii.empirewandplus.spells;
 
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import moe.myuuiii.empirewandplus.Data;
-import net.md_5.bungee.api.ChatColor;
+import moe.myuuiii.empirewandplus.Spells;
+import moe.myuuiii.empirewandplus.handlers.CloudHandler;
 
-public class CloudSpell {
+public class BloodCloudSpell {
 	//
 	// Settings
 	//
@@ -15,18 +17,18 @@ public class CloudSpell {
 
 	public static void Execute(Location loc, Player p) {
 
-		if (Data.cloudUsers.contains(p.getUniqueId())) {
-			p.sendMessage(Data.prefix + ChatColor.GRAY + "Deactivated cloud flight");
+		if (Data.bloodCloudUsers.contains(p.getUniqueId())) {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Deactivated " + Spells.BloodCloud);
 			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
 				p.setAllowFlight(false);
 			}
-			Data.cloudUsers.remove(p.getUniqueId());
+			CloudHandler.DisableCloud(p.getUniqueId());
 		} else {
-			p.sendMessage(Data.prefix + ChatColor.GRAY + "Activated cloud flight");
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Activated " + Spells.BloodCloud);
 			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
 				p.setAllowFlight(true);
 			}
-			Data.cloudUsers.add(p.getUniqueId());
+			Data.bloodCloudUsers.add(p.getUniqueId());
 		}
 	}
 }

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialCloudSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialCloudSpell.java
@@ -1,0 +1,34 @@
+package moe.myuuiii.empirewandplus.spells;
+
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Spells;
+import moe.myuuiii.empirewandplus.handlers.CloudHandler;
+
+public class CelestialCloudSpell {
+	//
+	// Settings
+	//
+	// No settings for this spell
+
+	public static void Execute(Location loc, Player p) {
+
+		if (Data.celestialCloudUsers.contains(p.getUniqueId())) {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Deactivated " + Spells.CelestialCloud);
+			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
+				p.setAllowFlight(false);
+			}
+			CloudHandler.DisableCloud(p.getUniqueId());
+		} else {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Activated " + Spells.CelestialCloud);
+			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
+				p.setAllowFlight(true);
+			}
+			Data.celestialCloudUsers.add(p.getUniqueId());
+		}
+	}
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireCloudSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireCloudSpell.java
@@ -1,0 +1,34 @@
+package moe.myuuiii.empirewandplus.spells;
+
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Spells;
+import moe.myuuiii.empirewandplus.handlers.CloudHandler;
+
+public class EmpireCloudSpell {
+	//
+	// Settings
+	//
+	// No settings for this spell
+
+	public static void Execute(Location loc, Player p) {
+
+		if (Data.empireCloudUsers.contains(p.getUniqueId())) {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Deactivated " + Spells.EmpireCloud);
+			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
+				p.setAllowFlight(false);
+			}
+			CloudHandler.DisableCloud(p.getUniqueId());
+		} else {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Activated " + Spells.EmpireCloud);
+			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
+				p.setAllowFlight(true);
+			}
+			Data.empireCloudUsers.add(p.getUniqueId());
+		}
+	}
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/PoisonCloudSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/PoisonCloudSpell.java
@@ -1,0 +1,34 @@
+package moe.myuuiii.empirewandplus.spells;
+
+import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Spells;
+import moe.myuuiii.empirewandplus.handlers.CloudHandler;
+
+public class PoisonCloudSpell {
+	//
+	// Settings
+	//
+	// No settings for this spell
+
+	public static void Execute(Location loc, Player p) {
+
+		if (Data.poisonCloudUsers.contains(p.getUniqueId())) {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Deactivated " + Spells.PoisonCloud);
+			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
+				p.setAllowFlight(false);
+			}
+			CloudHandler.DisableCloud(p.getUniqueId());
+		} else {
+			p.sendMessage(Data.prefix + ChatColor.GRAY + "Activated " + Spells.PoisonCloud);
+			if (!p.getGameMode().equals(GameMode.CREATIVE)) {
+				p.setAllowFlight(true);
+			}
+			Data.poisonCloudUsers.add(p.getUniqueId());
+		}
+	}
+}


### PR DESCRIPTION
# In this pull request

## Spells

- Created **Blood Cloud** spell (bound to blood wand)
- Created **Celestial Cloud** spell (bound to celestial wand)
- Created **Empire Cloud** spell (bound to empire wand)
- Created **Poison Cloud** spell (bound to poison scythe wand)
- Removed **Cloud** spell (previously bound to empire wand)

## Handlers

- Created a Cloud Handler which will remove the user from every cloud list to disable the clouds for every type if one of the clouds is disabled

- Registered new spell onto Spell Handler

## Runnables

- Created **Blood Cloud** runnable
- Created **Celestial Cloud** runnable
- Created **Empire Cloud** runnable
- Created **Poison Cloud** runnable
- Removed **Cloud** runnable

closes #23 
closes #21 
closes #20 
closes #19 
closes #18 

