### PR TITLE
Changed the potion effect entity checks for spells

### DIFF
--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/BloodWaveSpellEffect.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/BloodWaveSpellEffect.java
@@ -8,6 +8,7 @@ import org.bukkit.Sound;
 import org.bukkit.Particle.DustOptions;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Snowball;
 import org.bukkit.potion.PotionEffect;
@@ -46,12 +47,18 @@ public class BloodWaveSpellEffect {
 					final List<Entity> near = (List<Entity>) s.getLocation().getWorld().getEntities();
 					for (final Entity en : near) {
 						if (en.getLocation().distance(s.getLocation()) <= _closeRange && en instanceof Damageable) {
-							if (en instanceof Player) {
-								Player p = (Player) en;
-								if (!Data.bloodUsers.contains(p.getUniqueId())) {
-									p.addPotionEffect(
-											new PotionEffect(PotionEffectType.WITHER, _witherDuration, 1, true, false));
+
+							if (en instanceof LivingEntity) {
+								LivingEntity targetEntity = (LivingEntity) en;
+
+								if (en instanceof Player) {
+									Player p = (Player) en;
+									if (Data.bloodUsers.contains(p.getUniqueId())) {
+										continue;
+									}
 								}
+								targetEntity.addPotionEffect(
+										new PotionEffect(PotionEffectType.WITHER, _witherDuration, 1, true, false));
 							}
 						}
 					}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/EmpireCometSpellEffect.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/EmpireCometSpellEffect.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.bukkit.Particle;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Snowball;
 import org.bukkit.potion.PotionEffect;
@@ -33,16 +34,20 @@ public class EmpireCometSpellEffect {
 
 						final List<Entity> near = (List<Entity>) s.getLocation().getWorld().getEntities();
 						for (final Entity en : near) {
+
 							if (en.getLocation().distance(s.getLocation()) <= _closeRange && en instanceof Damageable) {
+
 								((Damageable) en).damage(_damage);
-								if (en instanceof Player) {
-									Player p = (Player) en;
-									p.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, _blindnessDuration,
-											1, true, false));
+
+								if (en instanceof LivingEntity) {
+									LivingEntity targetEntity = (LivingEntity) en;
+
+									targetEntity.addPotionEffect(
+											new PotionEffect(PotionEffectType.BLINDNESS, _blindnessDuration, 1, true,
+													false));
 								}
 							}
 						}
-
 						this.cancel();
 					}
 

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/LightningSpellEffect.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/LightningSpellEffect.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.bukkit.Particle;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Snowball;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -30,7 +31,8 @@ public class LightningSpellEffect {
 						s.getWorld().createExplosion(s.getLocation(), _explosionSize);
 						final List<Entity> near = (List<Entity>) s.getLocation().getWorld().getEntities();
 						for (final Entity en : near) {
-							if (en.getLocation().distance(s.getLocation()) <= _closeRange && en instanceof Damageable) {
+							if (en.getLocation().distance(s.getLocation()) <= _closeRange
+									&& en instanceof Damageable) {
 								((Damageable) en).damage(_damage);
 							}
 						}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/PoisonWaveSpellEffect.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spellEffects/PoisonWaveSpellEffect.java
@@ -8,6 +8,7 @@ import org.bukkit.Sound;
 import org.bukkit.Particle.DustOptions;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Snowball;
 import org.bukkit.potion.PotionEffect;
@@ -43,12 +44,19 @@ public class PoisonWaveSpellEffect {
 					final List<Entity> near = (List<Entity>) s.getLocation().getWorld().getEntities();
 					for (final Entity en : near) {
 						if (en.getLocation().distance(s.getLocation()) <= _closeRange && en instanceof Damageable) {
-							if (en instanceof Player) {
-								Player p = (Player) en;
-								if (!Data.poisonUsers.contains(p.getUniqueId())) {
-									p.addPotionEffect(
-											new PotionEffect(PotionEffectType.POISON, _poisonDuration, 1, true, false));
+
+							if (en instanceof LivingEntity) {
+								LivingEntity targetEntity = (LivingEntity) en;
+
+								if (en instanceof Player) {
+									Player p = (Player) en;
+									if (Data.poisonUsers.contains(p.getUniqueId())) {
+										continue;
+									}
 								}
+
+								targetEntity.addPotionEffect(
+										new PotionEffect(PotionEffectType.POISON, _poisonDuration, 1, true, false));
 							}
 						}
 					}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/BloodSparkSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/BloodSparkSpell.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -36,13 +37,11 @@ public class BloodSparkSpell {
 
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
-			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Damageable) {
+			if (en.getLocation().distance(loc) <= _closeRange && en instanceof LivingEntity) {
 				((Damageable) en).damage(_damage);
-				if (en instanceof Player) {
-					Player targetPL = (Player) en;
-					targetPL.addPotionEffect(
-							new PotionEffect(PotionEffectType.WITHER, _witherDuration, 1, true, false));
-				}
+				LivingEntity targetEntity = (LivingEntity) en;
+				targetEntity.addPotionEffect(
+						new PotionEffect(PotionEffectType.WITHER, _witherDuration, 1, true, false));
 			}
 		}
 	}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialStunSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialStunSpell.java
@@ -33,10 +33,12 @@ public class CelestialStunSpell {
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
 			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Entity) {
-				((LivingEntity) en)
-						.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, _slowDuration, 255, true, false));
-				((LivingEntity) en).addPotionEffect(
-						new PotionEffect(PotionEffectType.BLINDNESS, _blindnessDuration, 1, true, false));
+				if (en instanceof LivingEntity) {
+					((LivingEntity) en)
+							.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, _slowDuration, 255, true, false));
+					((LivingEntity) en).addPotionEffect(
+							new PotionEffect(PotionEffectType.BLINDNESS, _blindnessDuration, 1, true, false));
+				}
 			}
 		}
 	}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireSparkSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireSparkSpell.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -36,13 +37,11 @@ public class EmpireSparkSpell {
 
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
-			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Damageable) {
+			if (en.getLocation().distance(loc) <= _closeRange && en instanceof LivingEntity) {
 				((Damageable) en).damage(_damage);
-				if (en instanceof Player) {
-					Player targetPL = (Player) en;
-					targetPL.addPotionEffect(
-							new PotionEffect(PotionEffectType.BLINDNESS, _blindnessDuration, 1, true, false));
-				}
+				LivingEntity targetEntity = (LivingEntity) en;
+				targetEntity.addPotionEffect(
+						new PotionEffect(PotionEffectType.BLINDNESS, _blindnessDuration, 1, true, false));
 			}
 		}
 	}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireStunSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireStunSpell.java
@@ -35,7 +35,7 @@ public class EmpireStunSpell {
 
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
-			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Entity) {
+			if (en.getLocation().distance(loc) <= _closeRange && en instanceof LivingEntity) {
 				((LivingEntity) en)
 						.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, _slowDuration, 255, true, false));
 				((LivingEntity) en).addPotionEffect(

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/IgniteSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/IgniteSpell.java
@@ -6,8 +6,8 @@ import org.bukkit.Sound;
 
 import java.util.List;
 
-import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
 public class IgniteSpell {
@@ -29,7 +29,7 @@ public class IgniteSpell {
 
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
-			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Damageable) {
+			if (en.getLocation().distance(loc) <= _closeRange && en instanceof LivingEntity) {
 				en.setFireTicks(_fireDuration);
 			}
 		}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/LaunchSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/LaunchSpell.java
@@ -5,7 +5,6 @@ import org.bukkit.Particle;
 
 import java.util.List;
 
-import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
@@ -25,7 +24,7 @@ public class LaunchSpell {
 
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
-			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Damageable) {
+			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Entity) {
 				en.setVelocity(new Vector(p.getVelocity().getX(), _launchHeightModifier, p.getVelocity().getZ()));
 			}
 		}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/PoisonSparkSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/PoisonSparkSpell.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -34,13 +35,11 @@ public class PoisonSparkSpell {
 
 		final List<Entity> near = (List<Entity>) loc.getWorld().getEntities();
 		for (final Entity en : near) {
-			if (en.getLocation().distance(loc) <= _closeRange && en instanceof Damageable) {
+			if (en.getLocation().distance(loc) <= _closeRange && en instanceof LivingEntity) {
 				((Damageable) en).damage(_damage);
-				if (en instanceof Player) {
-					Player targetPL = (Player) en;
-					targetPL.addPotionEffect(
-							new PotionEffect(PotionEffectType.POISON, _poisonDuration, 1, true, false));
-				}
+				LivingEntity targetEntity = (LivingEntity) en;
+				targetEntity.addPotionEffect(
+						new PotionEffect(PotionEffectType.POISON, _poisonDuration, 1, true, false));
 			}
 		}
 	}


### PR DESCRIPTION
# In this pull request

## Spell handling
- For all spells that add potion effects to targets, changed the entity detection from "Player" instance to "LivingEntity" instance so that mobs will also get the poison effects (closes #54)