### PR TITLE
Added Cast Ranges and applied them to instant cast spells

### DIFF
--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/CastRange.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/CastRange.java
@@ -1,0 +1,7 @@
+package moe.myuuiii.empirewandplus;
+
+public class CastRange {
+	public static int Close = 7;
+	public static int Medium = 15;
+	public static int Long = 25;
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Extensions.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Extensions.java
@@ -1,0 +1,12 @@
+package moe.myuuiii.empirewandplus;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class Extensions {
+	public static boolean CheckIfInRange(int range, Location loc, Player player) {
+		if (loc.distance(player.getLocation()) <= range)
+			return true;
+		return false;
+	}
+}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/BloodSparkSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/BloodSparkSpell.java
@@ -15,6 +15,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.Extensions;
+import moe.myuuiii.empirewandplus.CastRange;
+
 public class BloodSparkSpell {
 	//
 	// Settings
@@ -24,6 +27,9 @@ public class BloodSparkSpell {
 	private static int _witherDuration = 100;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.FIREWORKS_SPARK, loc, 100, 0, 0, 0, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CaptureSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CaptureSpell.java
@@ -8,17 +8,19 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class CaptureSpell {
 
 	//
 	// Settings
 	//
 	private static double _closeRange = 3.0;
-	private static double _captureRange = 15.0;
 
 	public static void Execute(Location loc, Player p) {
 
-		if (loc.distance(p.getLocation()) > _captureRange)
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
 			return;
 
 		loc.add(0, 1, 0);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialConfuseSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialConfuseSpell.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class CelestialConfuseSpell {
 	//
 	// Settings
@@ -22,6 +25,10 @@ public class CelestialConfuseSpell {
 	private static int _closeRange = 3;
 
 	public static void Execute(Location loc, Player p) {
+
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.CLOUD, loc, 125, 1, 1, 1, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialStunSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/CelestialStunSpell.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class CelestialStunSpell {
 	//
 	// Settings
@@ -21,6 +24,10 @@ public class CelestialStunSpell {
 	public static int _blindnessDuration = 100;
 
 	public static void Execute(Location loc, Player p) {
+
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.FIREWORKS_SPARK, loc, 100, 0.5, 1, 0.5, 0.5);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireConfuseSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireConfuseSpell.java
@@ -12,6 +12,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class EmpireConfuseSpell {
 	//
 	// Settings
@@ -22,6 +25,9 @@ public class EmpireConfuseSpell {
 	private static int _closeRange = 3;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.REVERSE_PORTAL, loc, 250, 1, 1, 1, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireSparkSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireSparkSpell.java
@@ -15,6 +15,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class EmpireSparkSpell {
 
 	//
@@ -25,6 +28,9 @@ public class EmpireSparkSpell {
 	private static int _blindnessDuration = 100;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.DRAGON_BREATH, loc, 100, 0, 0, 0, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireStunSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/EmpireStunSpell.java
@@ -14,6 +14,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class EmpireStunSpell {
 	//
 	// Settings
@@ -23,6 +26,9 @@ public class EmpireStunSpell {
 	public static int _blindnessDuration = 100;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.DRAGON_BREATH, loc, 100, 0.5, 1, 0.5, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/IgniteSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/IgniteSpell.java
@@ -10,6 +10,9 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class IgniteSpell {
 	//
 	// Settings
@@ -18,6 +21,9 @@ public class IgniteSpell {
 	private static int _fireDuration = 150;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.SMOKE_LARGE, loc, 100, 1, 1, 1, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/LaunchSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/LaunchSpell.java
@@ -9,6 +9,9 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class LaunchSpell {
 
 	//
@@ -18,6 +21,9 @@ public class LaunchSpell {
 	private static double _launchHeightModifier = 2;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Long, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.CLOUD, loc, 250, 1.5, 0, 1.5, 0.1);

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/PoisonSparkSpell.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/spells/PoisonSparkSpell.java
@@ -15,6 +15,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import moe.myuuiii.empirewandplus.CastRange;
+import moe.myuuiii.empirewandplus.Extensions;
+
 public class PoisonSparkSpell {
 	//
 	// Settings
@@ -24,6 +27,9 @@ public class PoisonSparkSpell {
 	private static int _poisonDuration = 150;
 
 	public static void Execute(Location loc, Player p) {
+		if (!Extensions.CheckIfInRange(CastRange.Medium, loc, p))
+			return;
+
 		loc.add(0, 1, 0);
 
 		p.getWorld().spawnParticle(Particle.SMOKE_LARGE, loc, 100, 0, 0, 0, 0.1);


### PR DESCRIPTION
# In this pull request

## Spell Handling
- Created spell cast ranges, spells that cast instantly at the target block will now have to be targeted at a block that is within the range of the spell. (closes #60)

## Spells
- To all spells that were instant-casts, spell cast range was added (closes #61)