### PR TITLE
Celestial wand still has "not implemented" note

### DIFF
--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/commands/GetWandCommand.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/commands/GetWandCommand.java
@@ -81,8 +81,6 @@ public class GetWandCommand implements CommandExecutor {
 							}
 							break;
 						case "celestial":
-							player.sendMessage(Data.prefix + ChatColor.GOLD + Data.wandNotImplementedYet);
-
 							if (player.hasPermission("celestial.get")) {
 								wand = new ItemStack(Material.AMETHYST_SHARD, 1);
 								wandMeta = wand.getItemMeta();


### PR DESCRIPTION
# In this pull request

# Commands
- Removed the "Not implemented" note from the celestial wand switch case (Fixes #67)