### PR TITLE
Go to previous spell when crouching

### DIFF
--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Extensions.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/Extensions.java
@@ -1,12 +1,39 @@
 package moe.myuuiii.empirewandplus;
 
+import java.util.List;
+
+import javax.naming.directory.ModificationItem;
+
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 public class Extensions {
 	public static boolean CheckIfInRange(int range, Location loc, Player player) {
 		if (loc.distance(player.getLocation()) <= range)
 			return true;
 		return false;
+	}
+
+	public static String GetNextSpell(List<String> spellList, ItemStack wand, Player player) {
+		Integer currentSpellIndex = spellList
+				.indexOf(wand.getItemMeta().getLore().get(0));
+
+		Integer modifier;
+		if (player.isSneaking()) {
+			modifier = -1;
+		} else {
+			modifier = 1;
+		}
+
+		Integer nextSpellIndex = currentSpellIndex + modifier;
+
+		if (nextSpellIndex >= spellList.size()) {
+			nextSpellIndex = 0;
+		} else if (nextSpellIndex < 0) {
+			nextSpellIndex = spellList.size() - 1;
+		}
+
+		return spellList.get(nextSpellIndex);
 	}
 }

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/BloodWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/BloodWandInteraction.java
@@ -1,6 +1,7 @@
 package moe.myuuiii.empirewandplus.listeners.wandinteraction;
 
 import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Extensions;
 import moe.myuuiii.empirewandplus.WandSpellLists;
 import moe.myuuiii.empirewandplus.handlers.SpellHandler;
 
@@ -51,21 +52,13 @@ public class BloodWandInteraction {
 				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, p.getLocation(), 250, 0.5, 0.0, 0.5, 0.05);
 
 				//
-				// Initial Spell Configuration
+				// Spell cycling
 				//
 				List<String> loreItems = new ArrayList<>();
 				if (wand.getItemMeta().hasLore()) {
 					loreItems = wand.getItemMeta().getLore();
 
-					Integer currentSpellIndex = WandSpellLists.BloodWandSpells
-							.indexOf(wand.getItemMeta().getLore().get(0));
-					Integer nextSpellIndex = currentSpellIndex + 1;
-
-					if (nextSpellIndex >= WandSpellLists.BloodWandSpells.size()) {
-						nextSpellIndex = 0;
-					}
-
-					loreItems.set(0, WandSpellLists.BloodWandSpells.get(nextSpellIndex));
+					loreItems.set(0, Extensions.GetNextSpell(WandSpellLists.BloodWandSpells, wand, p));
 				} else {
 					loreItems.add(WandSpellLists.BloodWandSpells.get(0));
 				}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/CelestialWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/CelestialWandInteraction.java
@@ -1,6 +1,7 @@
 package moe.myuuiii.empirewandplus.listeners.wandinteraction;
 
 import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Extensions;
 import moe.myuuiii.empirewandplus.WandSpellLists;
 import moe.myuuiii.empirewandplus.handlers.SpellHandler;
 
@@ -51,21 +52,13 @@ public class CelestialWandInteraction {
 				p.getWorld().spawnParticle(Particle.CLOUD, p.getLocation(), 125, 0.5, 0.0, 0.5, 0.05);
 
 				//
-				// Initial Spell Configuration
+				// Spell cycling
 				//
 				List<String> loreItems = new ArrayList<>();
 				if (wand.getItemMeta().hasLore()) {
 					loreItems = wand.getItemMeta().getLore();
 
-					Integer currentSpellIndex = WandSpellLists.CelestialWandSpells
-							.indexOf(wand.getItemMeta().getLore().get(0));
-					Integer nextSpellIndex = currentSpellIndex + 1;
-
-					if (nextSpellIndex >= WandSpellLists.CelestialWandSpells.size()) {
-						nextSpellIndex = 0;
-					}
-
-					loreItems.set(0, WandSpellLists.CelestialWandSpells.get(nextSpellIndex));
+					loreItems.set(0, Extensions.GetNextSpell(WandSpellLists.CelestialWandSpells, wand, p));
 				} else {
 					loreItems.add(WandSpellLists.CelestialWandSpells.get(0));
 				}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/EmpireWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/EmpireWandInteraction.java
@@ -1,6 +1,7 @@
 package moe.myuuiii.empirewandplus.listeners.wandinteraction;
 
 import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Extensions;
 import moe.myuuiii.empirewandplus.WandSpellLists;
 import moe.myuuiii.empirewandplus.handlers.SpellHandler;
 
@@ -51,22 +52,14 @@ public class EmpireWandInteraction {
 				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, p.getLocation(), 250, 0.5, 0.0, 0.5, 0.05);
 
 				//
-				// Initial Spell Configuration
+				// Spell cycling
 				//
 				List<String> loreItems = new ArrayList<>();
 
 				if (wand.getItemMeta().hasLore()) {
 					loreItems = wand.getItemMeta().getLore();
 
-					Integer currentSpellIndex = WandSpellLists.EmpireWandSpells
-							.indexOf(wand.getItemMeta().getLore().get(0));
-					Integer nextSpellIndex = currentSpellIndex + 1;
-
-					if (nextSpellIndex >= WandSpellLists.EmpireWandSpells.size()) {
-						nextSpellIndex = 0;
-					}
-
-					loreItems.set(0, WandSpellLists.EmpireWandSpells.get(nextSpellIndex));
+					loreItems.set(0, Extensions.GetNextSpell(WandSpellLists.EmpireWandSpells, wand, p));
 				} else {
 					loreItems.add(WandSpellLists.EmpireWandSpells.get(0));
 				}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/HellWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/HellWandInteraction.java
@@ -1,6 +1,7 @@
 package moe.myuuiii.empirewandplus.listeners.wandinteraction;
 
 import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Extensions;
 import moe.myuuiii.empirewandplus.WandSpellLists;
 import moe.myuuiii.empirewandplus.handlers.SpellHandler;
 
@@ -51,21 +52,13 @@ public class HellWandInteraction {
 				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, p.getLocation(), 250, 0.5, 0.0, 0.5, 0.05);
 
 				//
-				// Initial Spell Configuration
+				// Spell cycling
 				//
 				List<String> loreItems = new ArrayList<>();
 				if (wand.getItemMeta().hasLore()) {
 					loreItems = wand.getItemMeta().getLore();
 
-					Integer currentSpellIndex = WandSpellLists.HellWandSpells
-							.indexOf(wand.getItemMeta().getLore().get(0));
-					Integer nextSpellIndex = currentSpellIndex + 1;
-
-					if (nextSpellIndex >= WandSpellLists.HellWandSpells.size()) {
-						nextSpellIndex = 0;
-					}
-
-					loreItems.set(0, WandSpellLists.HellWandSpells.get(nextSpellIndex));
+					loreItems.set(0, Extensions.GetNextSpell(WandSpellLists.HellWandSpells, wand, p));
 				} else {
 					loreItems.add(WandSpellLists.HellWandSpells.get(0));
 				}

--- a/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/ScytheWandInteraction.java
+++ b/src/EmpireWandPlus/src/main/java/moe/myuuiii/empirewandplus/listeners/wandinteraction/ScytheWandInteraction.java
@@ -1,6 +1,7 @@
 package moe.myuuiii.empirewandplus.listeners.wandinteraction;
 
 import moe.myuuiii.empirewandplus.Data;
+import moe.myuuiii.empirewandplus.Extensions;
 import moe.myuuiii.empirewandplus.WandSpellLists;
 import moe.myuuiii.empirewandplus.handlers.SpellHandler;
 
@@ -51,22 +52,14 @@ public class ScytheWandInteraction {
 				p.getWorld().spawnParticle(Particle.SMOKE_NORMAL, p.getLocation(), 250, 0.5, 0.0, 0.5, 0.05);
 
 				//
-				// Initial Spell Configuration
+				// Spell cycling
 				//
 				List<String> loreItems = new ArrayList<>();
 
 				if (wand.getItemMeta().hasLore()) {
 					loreItems = wand.getItemMeta().getLore();
 
-					Integer currentSpellIndex = WandSpellLists.PoisonScytheWandSpells
-							.indexOf(wand.getItemMeta().getLore().get(0));
-					Integer nextSpellIndex = currentSpellIndex + 1;
-
-					if (nextSpellIndex >= WandSpellLists.PoisonScytheWandSpells.size()) {
-						nextSpellIndex = 0;
-					}
-
-					loreItems.set(0, WandSpellLists.PoisonScytheWandSpells.get(nextSpellIndex));
+					loreItems.set(0, Extensions.GetNextSpell(WandSpellLists.PoisonScytheWandSpells, wand, p));
 				} else {
 					loreItems.add(WandSpellLists.PoisonScytheWandSpells.get(0));
 				}


### PR DESCRIPTION
# In this pull request

## Spell Handling
- When crouching, the wand will switch to the previous spell (Fixes #71)
- Created extensions for switching spells (Fixes #72)

