### PR TITLE
Wand switching showing the right wand as a prefix, instead of it always being [EmpireWand]

### DIFF
--- a/src/main/java/com/myuuiii/empirewandplus/Abstracts/Wand.java
+++ b/src/main/java/com/myuuiii/empirewandplus/Abstracts/Wand.java
@@ -23,6 +23,8 @@ public abstract class Wand {
 
     public abstract String getDisplayName();
 
+    public abstract String getPrefix();
+
     public abstract ItemStack getItem();
 
     // Permission Names

--- a/src/main/java/com/myuuiii/empirewandplus/EmpireWandPlus.java
+++ b/src/main/java/com/myuuiii/empirewandplus/EmpireWandPlus.java
@@ -29,7 +29,7 @@ public final class EmpireWandPlus extends JavaPlugin {
     public static EmpireWandPlus _plugin;
     public static HashMap<String, Spell> spellHashMap = getSpellHashMap();
     public static HashMap<String, SpellEffect> spellEffectHashMap = getSpellEffectHashMap();
-    public static String Prefix = colorText("&8[&6EmpireWand&8]&r ");
+    public static String Prefix = colorText("&8[&6EmpireWandPlus&8]&r ");
     public static String PermissionPrefix = "empirewandplus.";
 
     public static HashMap<String, Wand> wandHashMap = new HashMap<>() {{

--- a/src/main/java/com/myuuiii/empirewandplus/Wands/BloodWand.java
+++ b/src/main/java/com/myuuiii/empirewandplus/Wands/BloodWand.java
@@ -12,6 +12,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import static com.myuuiii.empirewandplus.Extensions.colorText;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +32,11 @@ public class BloodWand extends Wand {
     @Override
     public String getDisplayName() {
         return ChatColor.RED + "Blood Wand";
+    }
+
+    @Override
+    public String getPrefix() {
+        return colorText("&8[&cBlood Wand&8]&r ");
     }
 
     @Override
@@ -60,5 +67,4 @@ public class BloodWand extends Wand {
         p.getWorld().spawnParticle(Particle.BLOCK_DUST, p.getLocation().add(0, 0.3, 0), 50, 0.3, 0.6, 0.3, 0.1,
                 Material.REDSTONE_BLOCK.createBlockData());
     }
-
 }

--- a/src/main/java/com/myuuiii/empirewandplus/Wands/ElementosWand.java
+++ b/src/main/java/com/myuuiii/empirewandplus/Wands/ElementosWand.java
@@ -12,6 +12,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import static com.myuuiii.empirewandplus.Extensions.colorText;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +36,12 @@ public class ElementosWand extends Wand {
     @Override
     public String getDisplayName() {
         return ChatColor.AQUA + "Elementos Wand";
+    }
+
+    
+    @Override
+    public String getPrefix() {
+        return colorText("&8[&3Elementos Wand&8]&r ");
     }
 
     @Override

--- a/src/main/java/com/myuuiii/empirewandplus/Wands/EmpireWand.java
+++ b/src/main/java/com/myuuiii/empirewandplus/Wands/EmpireWand.java
@@ -12,6 +12,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import static com.myuuiii.empirewandplus.Extensions.colorText;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,6 +65,11 @@ public class EmpireWand extends Wand {
     public String getDisplayName() {
         return ChatColor.GOLD + "Empire Wand";
     }
+    
+    @Override
+    public String getPrefix() {
+        return colorText("&8[&6Empire Wand&8]&r ");
+    }
 
     @Override
     public ItemStack getItem() {
@@ -91,5 +98,4 @@ public class EmpireWand extends Wand {
         p.getWorld().spawnParticle(Particle.ENCHANTMENT_TABLE, p.getLocation(), 50, 0.4, 0.5, 0.4, 0.0);
         p.getWorld().spawnParticle(Particle.SPELL_WITCH, p.getLocation(), 100, 0, 0.7, 0, 0.01);
     }
-
 }

--- a/src/main/java/com/myuuiii/empirewandplus/Wands/WandMethods.java
+++ b/src/main/java/com/myuuiii/empirewandplus/Wands/WandMethods.java
@@ -30,7 +30,7 @@ public class WandMethods {
 
         meta.setLore(loreItems);
         wandItem.setItemMeta(meta);
-        p.sendMessage(EmpireWandPlus.Prefix + wandItem.getItemMeta().getLore().get(0));
+        p.sendMessage(wand.getPrefix() + wandItem.getItemMeta().getLore().get(0));
     }
 
     public static void ExecuteSpellOnLeftClick(PlayerInteractEvent e, Player p, ItemStack wand) {


### PR DESCRIPTION
- [x] Code has been tested

- Changed spell switch messages